### PR TITLE
DFN-15360 - Implemented async bdd test support.

### DIFF
--- a/FluentTestScaffold.Bdd/TestScaffoldAsyncBddExtensions.cs
+++ b/FluentTestScaffold.Bdd/TestScaffoldAsyncBddExtensions.cs
@@ -1,0 +1,264 @@
+// ReSharper disable once CheckNamespace
+namespace FluentTestScaffold.Core
+{
+    /// <summary>
+    /// Extension methods to support asynchronous BDD style Tests with the Test Scaffold
+    /// </summary>
+    public static class TestScaffoldAsyncBddExtensions
+    {
+        // === Async extensions on TestScaffold ===
+
+        /// <summary>
+        /// Defines an asynchronous given step to prepare your test state
+        /// </summary>
+        public static Task<TestScaffold> GivenAsync(this TestScaffold testScaffold, string description, Func<TestScaffold, Task> action)
+        {
+            return TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(GivenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous given step to prepare your test state and injects a specific service into the step definition
+        /// </summary>
+        public static Task<TestScaffold> GivenAsync<TService>(this TestScaffold testScaffold, string description, Func<TService, Task> action) where TService : notnull
+        {
+            return TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(GivenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous when step to perform an action
+        /// </summary>
+        public static Task<TestScaffold> WhenAsync(this TestScaffold testScaffold, string description, Func<TestScaffold, Task> action)
+        {
+            return TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(WhenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous when step to perform an action and injects a specific service into the step definition
+        /// </summary>
+        public static Task<TestScaffold> WhenAsync<TService>(this TestScaffold testScaffold, string description, Func<TService, Task> action) where TService : notnull
+        {
+            return TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(WhenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous then step to assert the outcome of the action
+        /// </summary>
+        public static Task<TestScaffold> ThenAsync(this TestScaffold testScaffold, string description, Func<TestScaffold, Task> action)
+        {
+            return TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(ThenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous then step to assert the outcome of the action and injects a specific service into the step definition
+        /// </summary>
+        public static Task<TestScaffold> ThenAsync<TService>(this TestScaffold testScaffold, string description, Func<TService, Task> action) where TService : notnull
+        {
+            return TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(ThenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous and step to add additional steps to your test
+        /// </summary>
+        public static Task<TestScaffold> AndAsync(this TestScaffold testScaffold, string description, Func<TestScaffold, Task> action)
+        {
+            return TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(AndAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous and step to add additional steps to your test and injects a specific service into the step definition
+        /// </summary>
+        public static Task<TestScaffold> AndAsync<TService>(this TestScaffold testScaffold, string description, Func<TService, Task> action) where TService : notnull
+        {
+            return TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(AndAsync), description, action);
+        }
+
+        /// <summary>
+        /// Catches an Exception from an asynchronous action and saves it to the TestScaffoldContext for assertion
+        /// </summary>
+        /// <param name="testScaffold"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        public static async Task CatchAsync<T>(this TestScaffold testScaffold, Func<Task> action) where T : Exception
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception e)
+            {
+                if (e is T)
+                    testScaffold.TestScaffoldContext.Set(e, "CaughtException");
+                else throw;
+            }
+        }
+
+        /// <summary>
+        /// Handles a caught exception with an asynchronous handler
+        /// </summary>
+        /// <param name="testScaffold"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        public static async Task HandleAsync<T>(this TestScaffold testScaffold, Func<T, Task> action) where T : Exception
+        {
+            if (!testScaffold.TestScaffoldContext.TryGetValue<T>("CaughtException", out var exception) || exception == null)
+                throw new InvalidOperationException($"Handle<{typeof(T).Name}> was called but no exception of type {typeof(T).Name} was caught. Ensure Catch<{typeof(T).Name}> is called before Handle.");
+            await action(exception);
+        }
+
+        // === Async extensions on Task<TestScaffold> for fluent chaining ===
+
+        /// <summary>
+        /// Adds a scenario definition to an async test chain
+        /// </summary>
+        public static async Task<TestScaffold> ScenarioAsync(this Task<TestScaffold> testScaffoldTask, string description)
+        {
+            var testScaffold = await testScaffoldTask;
+            TestScaffoldBddHelpers.LogStep(testScaffold, nameof(ScenarioAsync), description);
+            return testScaffold;
+        }
+
+        /// <summary>
+        /// Defines an asynchronous given step in an async test chain
+        /// </summary>
+        public static async Task<TestScaffold> GivenAsync(this Task<TestScaffold> testScaffoldTask, string description, Func<TestScaffold, Task> action)
+        {
+            var testScaffold = await testScaffoldTask;
+            return await TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(GivenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous given step in an async test chain and injects a specific service into the step definition
+        /// </summary>
+        public static async Task<TestScaffold> GivenAsync<TService>(this Task<TestScaffold> testScaffoldTask, string description, Func<TService, Task> action) where TService : notnull
+        {
+            var testScaffold = await testScaffoldTask;
+            return await TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(GivenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines a synchronous given step in an async test chain
+        /// </summary>
+        public static async Task<TestScaffold> GivenAsync(this Task<TestScaffold> testScaffoldTask, string description, Action<TestScaffold> action)
+        {
+            var testScaffold = await testScaffoldTask;
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(GivenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines a synchronous given step in an async test chain and injects a specific service into the step definition
+        /// </summary>
+        public static async Task<TestScaffold> GivenAsync<TService>(this Task<TestScaffold> testScaffoldTask, string description, Action<TService> action) where TService : notnull
+        {
+            var testScaffold = await testScaffoldTask;
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(GivenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous when step in an async test chain
+        /// </summary>
+        public static async Task<TestScaffold> WhenAsync(this Task<TestScaffold> testScaffoldTask, string description, Func<TestScaffold, Task> action)
+        {
+            var testScaffold = await testScaffoldTask;
+            return await TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(WhenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous when step in an async test chain and injects a specific service into the step definition
+        /// </summary>
+        public static async Task<TestScaffold> WhenAsync<TService>(this Task<TestScaffold> testScaffoldTask, string description, Func<TService, Task> action) where TService : notnull
+        {
+            var testScaffold = await testScaffoldTask;
+            return await TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(WhenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines a synchronous when step in an async test chain
+        /// </summary>
+        public static async Task<TestScaffold> WhenAsync(this Task<TestScaffold> testScaffoldTask, string description, Action<TestScaffold> action)
+        {
+            var testScaffold = await testScaffoldTask;
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(WhenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines a synchronous when step in an async test chain and injects a specific service into the step definition
+        /// </summary>
+        public static async Task<TestScaffold> WhenAsync<TService>(this Task<TestScaffold> testScaffoldTask, string description, Action<TService> action) where TService : notnull
+        {
+            var testScaffold = await testScaffoldTask;
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(WhenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous then step in an async test chain
+        /// </summary>
+        public static async Task<TestScaffold> ThenAsync(this Task<TestScaffold> testScaffoldTask, string description, Func<TestScaffold, Task> action)
+        {
+            var testScaffold = await testScaffoldTask;
+            return await TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(ThenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous then step in an async test chain and injects a specific service into the step definition
+        /// </summary>
+        public static async Task<TestScaffold> ThenAsync<TService>(this Task<TestScaffold> testScaffoldTask, string description, Func<TService, Task> action) where TService : notnull
+        {
+            var testScaffold = await testScaffoldTask;
+            return await TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(ThenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines a synchronous then step in an async test chain
+        /// </summary>
+        public static async Task<TestScaffold> ThenAsync(this Task<TestScaffold> testScaffoldTask, string description, Action<TestScaffold> action)
+        {
+            var testScaffold = await testScaffoldTask;
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(ThenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines a synchronous then step in an async test chain and injects a specific service into the step definition
+        /// </summary>
+        public static async Task<TestScaffold> ThenAsync<TService>(this Task<TestScaffold> testScaffoldTask, string description, Action<TService> action) where TService : notnull
+        {
+            var testScaffold = await testScaffoldTask;
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(ThenAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous and step in an async test chain
+        /// </summary>
+        public static async Task<TestScaffold> AndAsync(this Task<TestScaffold> testScaffoldTask, string description, Func<TestScaffold, Task> action)
+        {
+            var testScaffold = await testScaffoldTask;
+            return await TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(AndAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines an asynchronous and step in an async test chain and injects a specific service into the step definition
+        /// </summary>
+        public static async Task<TestScaffold> AndAsync<TService>(this Task<TestScaffold> testScaffoldTask, string description, Func<TService, Task> action) where TService : notnull
+        {
+            var testScaffold = await testScaffoldTask;
+            return await TestScaffoldBddHelpers.PerformActionAsync(testScaffold, nameof(AndAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines a synchronous and step in an async test chain
+        /// </summary>
+        public static async Task<TestScaffold> AndAsync(this Task<TestScaffold> testScaffoldTask, string description, Action<TestScaffold> action)
+        {
+            var testScaffold = await testScaffoldTask;
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(AndAsync), description, action);
+        }
+
+        /// <summary>
+        /// Defines a synchronous and step in an async test chain and injects a specific service into the step definition
+        /// </summary>
+        public static async Task<TestScaffold> AndAsync<TService>(this Task<TestScaffold> testScaffoldTask, string description, Action<TService> action) where TService : notnull
+        {
+            var testScaffold = await testScaffoldTask;
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(AndAsync), description, action);
+        }
+    }
+}

--- a/FluentTestScaffold.Bdd/TestScaffoldBddExtensions.cs
+++ b/FluentTestScaffold.Bdd/TestScaffoldBddExtensions.cs
@@ -14,7 +14,7 @@ namespace FluentTestScaffold.Core
         /// </summary>
         public static TestScaffold Scenario(this TestScaffold testScaffold, string description)
         {
-            LogStep(testScaffold, nameof(Scenario), description);
+            TestScaffoldBddHelpers.LogStep(testScaffold, nameof(Scenario), description);
             return testScaffold;
         }
         /// <summary>
@@ -22,7 +22,7 @@ namespace FluentTestScaffold.Core
         /// </summary>
         public static TestScaffold Given(this TestScaffold testScaffold, string description, Action<TestScaffold> action)
         {
-            return PerformAction(testScaffold, nameof(Given), description, action);
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(Given), description, action);
         }
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace FluentTestScaffold.Core
         /// </summary>
         public static TestScaffold Given<TService>(this TestScaffold testScaffold, string description, Action<TService> action) where TService : notnull
         {
-            return PerformAction(testScaffold, nameof(Given), description, action);
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(Given), description, action);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace FluentTestScaffold.Core
         /// </summary>
         public static TestScaffold When(this TestScaffold testScaffold, string description, Action<TestScaffold> action)
         {
-            return PerformAction(testScaffold, nameof(When), description, action);
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(When), description, action);
         }
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace FluentTestScaffold.Core
         /// </summary>
         public static TestScaffold When<TService>(this TestScaffold testScaffold, string description, Action<TService> action) where TService : notnull
         {
-            return PerformAction(testScaffold, nameof(When), description, action);
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(When), description, action);
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace FluentTestScaffold.Core
         /// </summary>
         public static TestScaffold Then(this TestScaffold testScaffold, string description, Action<TestScaffold> action)
         {
-            return PerformAction(testScaffold, nameof(Then), description, action);
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(Then), description, action);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace FluentTestScaffold.Core
         /// </summary>
         public static TestScaffold Then<TService>(this TestScaffold testScaffold, string description, Action<TService> action) where TService : notnull
         {
-            return PerformAction(testScaffold, nameof(Then), description, action);
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(Then), description, action);
         }
 
 
@@ -71,7 +71,7 @@ namespace FluentTestScaffold.Core
         /// </summary>
         public static TestScaffold And(this TestScaffold testScaffold, string description, Action<TestScaffold> action)
         {
-            return PerformAction(testScaffold, nameof(And), description, action);
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(And), description, action);
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace FluentTestScaffold.Core
         /// </summary>
         public static TestScaffold And<TService>(this TestScaffold testScaffold, string description, Action<TService> action) where TService : notnull
         {
-            return PerformAction(testScaffold, nameof(And), description, action);
+            return TestScaffoldBddHelpers.PerformAction(testScaffold, nameof(And), description, action);
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace FluentTestScaffold.Core
         /// <param name="testScaffold"></param>
         /// <param name="action"></param>
         /// <typeparam name="T"></typeparam>
-        public static void Catch<T>(this TestScaffold testScaffold, Action action)
+        public static void Catch<T>(this TestScaffold testScaffold, Action action) where T : Exception
         {
             try
             {
@@ -108,38 +108,11 @@ namespace FluentTestScaffold.Core
         /// <param name="testScaffold"></param>
         /// <param name="action"></param>
         /// <typeparam name="T"></typeparam>
-        public static void Handle<T>(this TestScaffold testScaffold, Action<T> action)
+        public static void Handle<T>(this TestScaffold testScaffold, Action<T> action) where T : Exception
         {
-            var exception = testScaffold.TestScaffoldContext.Get<T>("CaughtException");
-            if (exception != null)
-                action(exception);
-        }
-
-
-        private static TestScaffold PerformAction(TestScaffold testScaffold, string actionType, string description, Action<TestScaffold> action)
-        {
-            var logger = testScaffold.ServiceProvider?.GetService<ITestScaffoldLogger>();
-            if (logger != null)
-                logger.Info(actionType + " " + description);
-
-            action(testScaffold);
-            return testScaffold;
-        }
-
-        private static TestScaffold PerformAction<TService>(TestScaffold testScaffold, string actionType, string description, Action<TService> action) where TService : notnull
-        {
-            LogStep(testScaffold, actionType, description);
-
-            var service = testScaffold.Resolve<TService>();
-            action(service);
-            return testScaffold;
-        }
-
-        private static void LogStep(TestScaffold testScaffold, string actionType, string description)
-        {
-            var logger = testScaffold.ServiceProvider?.GetService<ITestScaffoldLogger>();
-            if (logger != null)
-                logger.Info(actionType + " " + description);
+            if(!testScaffold.TestScaffoldContext.TryGetValue<T>("CaughtException", out var exception) || exception == null)
+                throw new InvalidOperationException($"Handle<{typeof(T).Name}> was called but no exception of type {typeof(T).Name} was caught. Ensure Catch<{typeof(T).Name}> is called before Handle.");
+            action(exception);
         }
     }
 }

--- a/FluentTestScaffold.Bdd/TestScaffoldBddHelpers.cs
+++ b/FluentTestScaffold.Bdd/TestScaffoldBddHelpers.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.DependencyInjection;
+
+// ReSharper disable once CheckNamespace
+namespace FluentTestScaffold.Core;
+
+/// <summary>
+/// Shared helper methods used by both synchronous and asynchronous BDD extension classes
+/// </summary>
+internal static class TestScaffoldBddHelpers
+{
+    internal static TestScaffold PerformAction(TestScaffold testScaffold, string actionType, string description, Action<TestScaffold> action)
+    {
+        LogStep(testScaffold, actionType, description);
+        action(testScaffold);
+        return testScaffold;
+    }
+
+    internal static TestScaffold PerformAction<TService>(TestScaffold testScaffold, string actionType, string description, Action<TService> action) where TService : notnull
+    {
+        LogStep(testScaffold, actionType, description);
+        var service = testScaffold.Resolve<TService>();
+        action(service);
+        return testScaffold;
+    }
+
+    internal static async Task<TestScaffold> PerformActionAsync(TestScaffold testScaffold, string actionType, string description, Func<TestScaffold, Task> action)
+    {
+        LogStep(testScaffold, actionType, description);
+        await action(testScaffold);
+        return testScaffold;
+    }
+
+    internal static async Task<TestScaffold> PerformActionAsync<TService>(TestScaffold testScaffold, string actionType, string description, Func<TService, Task> action) where TService : notnull
+    {
+        LogStep(testScaffold, actionType, description);
+        var service = testScaffold.Resolve<TService>();
+        await action(service);
+        return testScaffold;
+    }
+
+    internal static void LogStep(TestScaffold testScaffold, string actionType, string description)
+    {
+        var logger = testScaffold.ServiceProvider?.GetService<ITestScaffoldLogger>();
+        logger?.Info(actionType + " " + description);
+    }
+}

--- a/Tests/FluentTestScaffold.Tests/AsyncBddTests.cs
+++ b/Tests/FluentTestScaffold.Tests/AsyncBddTests.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Autofac;
+using FluentTestScaffold.Core;
+using FluentTestScaffold.Sample;
+using FluentTestScaffold.Sample.Data;
+using FluentTestScaffold.Sample.Services;
+using FluentTestScaffold.Tests.CustomBuilder;
+using FluentTestScaffold.Tests.CustomBuilder.Autofac;
+using FluentTestScaffold.Tests.CustomBuilder.DataTemplates;
+using NUnit.Framework;
+
+
+namespace FluentTestScaffold.Tests;
+
+public class AsyncBddTests
+{
+    private TestScaffold CreateTestScaffold()
+    {
+        return new TestScaffold()
+            .UsingNunit()
+            .UseAutofac(new AutofacAppServicesBuilder(), serviceBuilder =>
+            {
+                serviceBuilder.RegisterAppServices();
+                serviceBuilder.Container.RegisterType<ShoppingCartService>();
+            })
+            .WithTemplate<ApplicationDataTemplates>(dt => dt.DefaultCatalogueAndUsers());
+    }
+
+    [Test]
+    public async Task CanRunAsyncBddTestWithInlineSteps()
+    {
+        var testScaffold = CreateTestScaffold();
+
+        await testScaffold
+            .Scenario("User can not add age restricted item to cart when under aged")
+            .GivenAsync<IUserRequestContext>("A user is authenticated", async requestContext =>
+            {
+                await Task.Run(() =>
+                    requestContext.AuthenticateUser(UserBuilder.Under18User.Email,
+                        UserBuilder.Under18User.Password));
+            })
+            .WhenAsync("The user attempts to add an item to the shopping cart", async ts =>
+            {
+                var dbContext = ts.Resolve<TestDbContext>();
+                var item = dbContext.Items.FirstOrDefault(i => i.Title == Defaults.CatalogueItems.DeadPool);
+                var shoppingCartService = ts.Resolve<ShoppingCartService>();
+                await ts.CatchAsync<InvalidOperationException>(async () =>
+                    await Task.Run(() => shoppingCartService.AddItemToCart(item!.Id)));
+            })
+            .ThenAsync("The user should not be able to add the item to the shopping cart", async ts =>
+            {
+                await ts.HandleAsync<InvalidOperationException>(async ex =>
+                {
+                    Assert.IsNotNull(ex);
+                    Assert.AreEqual("You must be over 15 to add this item", ex.Message);
+                    await Task.CompletedTask;
+                });
+            });
+    }
+
+    [Test]
+    public async Task CanRunAsyncBddTestWithMethodReferences()
+    {
+        var testScaffold = CreateTestScaffold();
+
+        await testScaffold
+            .Scenario("User can not add age restricted item to cart when under aged")
+            .GivenAsync<IUserRequestContext>("A user is authenticated", AuthenticateUnderAgeUserAsync)
+            .WhenAsync("The user attempts to add an item to the shopping cart", WhenTheUserAddsItemToCartAsync)
+            .ThenAsync("The user should not be able to add the item to the shopping cart", ThenTheUserCanNotAddAgeRestrictedContentAsync);
+    }
+
+    [Test]
+    public async Task CanChainAsyncAndSyncSteps()
+    {
+        var testScaffold = CreateTestScaffold();
+
+        await testScaffold
+            .Scenario("User can not add age restricted item to cart when under aged")
+            .GivenAsync<IUserRequestContext>("A user is authenticated", async requestContext =>
+            {
+                await Task.Run(() =>
+                    requestContext.AuthenticateUser(UserBuilder.Under18User.Email,
+                        UserBuilder.Under18User.Password));
+            })
+            .WhenAsync("The user attempts to add an item to the shopping cart", (Action<TestScaffold>)(ts =>
+            {
+                var dbContext = ts.Resolve<TestDbContext>();
+                var item = dbContext.Items.FirstOrDefault(i => i.Title == Defaults.CatalogueItems.DeadPool);
+                var shoppingCartService = ts.Resolve<ShoppingCartService>();
+                ts.Catch<InvalidOperationException>(() => shoppingCartService.AddItemToCart(item!.Id));
+            }))
+            .ThenAsync("The user should not be able to add the item to the shopping cart", (Action<TestScaffold>)(ts =>
+            {
+                ts.Handle<InvalidOperationException>(ex =>
+                {
+                    Assert.IsNotNull(ex);
+                    Assert.AreEqual("You must be over 15 to add this item", ex.Message);
+                });
+            }));
+    }
+
+    [Test]
+    public async Task CanUseAsyncAndStep()
+    {
+        var executionOrder = new System.Collections.Generic.List<string>();
+
+        var testScaffold = CreateTestScaffold();
+
+        await testScaffold
+            .Scenario("Async And step works correctly")
+            .GivenAsync("A precondition", async ts =>
+            {
+                executionOrder.Add("given");
+                await Task.CompletedTask;
+            })
+            .AndAsync("An additional precondition", async ts =>
+            {
+                executionOrder.Add("and");
+                await Task.CompletedTask;
+            })
+            .WhenAsync("An action is performed", async ts =>
+            {
+                executionOrder.Add("when");
+                await Task.CompletedTask;
+            })
+            .ThenAsync("The outcome is verified", async ts =>
+            {
+                executionOrder.Add("then");
+                await Task.CompletedTask;
+            });
+
+        Assert.AreEqual(4, executionOrder.Count);
+        Assert.AreEqual("given", executionOrder[0]);
+        Assert.AreEqual("and", executionOrder[1]);
+        Assert.AreEqual("when", executionOrder[2]);
+        Assert.AreEqual("then", executionOrder[3]);
+    }
+
+    [Test]
+    public async Task CanUseAsyncGivenWithInjectedService()
+    {
+        var testScaffold = CreateTestScaffold();
+        var authenticated = false;
+
+        await testScaffold
+            .Scenario("Async service injection works in Given step")
+            .GivenAsync<IUserRequestContext>("A user is authenticated via async step", async requestContext =>
+            {
+                await Task.Run(() =>
+                {
+                    requestContext.AuthenticateUser(UserBuilder.Over18User.Email,
+                        UserBuilder.Over18User.Password);
+                    authenticated = true;
+                });
+            })
+            .ThenAsync("The user should be authenticated", async ts =>
+            {
+                Assert.IsTrue(authenticated);
+                var userContext = ts.Resolve<IUserRequestContext>();
+                Assert.IsNotNull(userContext.CurrentUser);
+                Assert.AreEqual(UserBuilder.Over18User.Email, userContext.CurrentUser!.Email);
+                await Task.CompletedTask;
+            });
+    }
+
+    [Test]
+    public async Task CanUseAsyncWhenWithInjectedService()
+    {
+        var testScaffold = CreateTestScaffold();
+
+        await testScaffold
+            .Scenario("Async service injection works in When step")
+            .GivenAsync<IUserRequestContext>("A user over 18 is authenticated", async requestContext =>
+            {
+                await Task.Run(() =>
+                    requestContext.AuthenticateUser(UserBuilder.Over18User.Email,
+                        UserBuilder.Over18User.Password));
+            })
+            .WhenAsync<ShoppingCartService>("The user adds an item to the cart", async shoppingCartService =>
+            {
+                var dbContext = testScaffold.Resolve<TestDbContext>();
+                var item = dbContext.Items.FirstOrDefault(i => i.Title == Defaults.CatalogueItems.Minions);
+                await Task.Run(() => shoppingCartService.AddItemToCart(item!.Id));
+            })
+            .ThenAsync("The item should be in the cart", async ts =>
+            {
+                var dbContext = ts.Resolve<TestDbContext>();
+                var userContext = ts.Resolve<IUserRequestContext>();
+                var cart = dbContext.ShoppingCart.FirstOrDefault(c => c.UserId == userContext.CurrentUser!.Id);
+                Assert.IsNotNull(cart);
+                Assert.IsTrue(cart!.Inventory.Any(i => i.Title == Defaults.CatalogueItems.Minions));
+                await Task.CompletedTask;
+            });
+    }
+
+    [Test]
+    public async Task AsyncCatchHandlesExpectedExceptionType()
+    {
+        var testScaffold = CreateTestScaffold();
+
+        await testScaffold
+            .Scenario("Async Catch stores exception for later assertion")
+            .GivenAsync<IUserRequestContext>("A user is authenticated", async requestContext =>
+            {
+                await Task.Run(() =>
+                    requestContext.AuthenticateUser(UserBuilder.Under18User.Email,
+                        UserBuilder.Under18User.Password));
+            })
+            .WhenAsync("The user attempts a restricted action", async ts =>
+            {
+                var dbContext = ts.Resolve<TestDbContext>();
+                var item = dbContext.Items.FirstOrDefault(i => i.Title == Defaults.CatalogueItems.DeadPool);
+                var shoppingCartService = ts.Resolve<ShoppingCartService>();
+                await ts.CatchAsync<InvalidOperationException>(async () =>
+                    await Task.Run(() => shoppingCartService.AddItemToCart(item!.Id)));
+            })
+            .ThenAsync("The exception should be available for assertion", async ts =>
+            {
+                await ts.HandleAsync<InvalidOperationException>(async ex =>
+                {
+                    Assert.IsNotNull(ex);
+                    Assert.That(ex.Message, Does.Contain("over 15"));
+                    await Task.CompletedTask;
+                });
+            });
+    }
+
+    [Test]
+    public async Task AsyncCatchRethrowsUnexpectedExceptionType()
+    {
+        var testScaffold = CreateTestScaffold();
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await testScaffold.CatchAsync<ArgumentException>(async () =>
+            {
+                await Task.Run(() => throw new InvalidOperationException("unexpected"));
+            });
+        });
+    }
+
+    [Test]
+    public async Task AsyncThenWithInjectedServiceWorks()
+    {
+        var testScaffold = CreateTestScaffold();
+
+        await testScaffold
+            .Scenario("Async Then with service injection")
+            .GivenAsync<IUserRequestContext>("A user over 18 is authenticated", async requestContext =>
+            {
+                await Task.Run(() =>
+                    requestContext.AuthenticateUser(UserBuilder.Over18User.Email,
+                        UserBuilder.Over18User.Password));
+            })
+            .ThenAsync<IUserRequestContext>("The user context should have the user", async userContext =>
+            {
+                Assert.IsNotNull(userContext.CurrentUser);
+                Assert.AreEqual(UserBuilder.Over18User.Email, userContext.CurrentUser!.Email);
+                await Task.CompletedTask;
+            });
+    }
+
+    [Test]
+    public async Task AsyncAndWithInjectedServiceWorks()
+    {
+        var testScaffold = CreateTestScaffold();
+
+        await testScaffold
+            .Scenario("Async And with service injection")
+            .GivenAsync<IUserRequestContext>("A user over 18 is authenticated", async requestContext =>
+            {
+                await Task.Run(() =>
+                    requestContext.AuthenticateUser(UserBuilder.Over18User.Email,
+                        UserBuilder.Over18User.Password));
+            })
+            .AndAsync<IUserRequestContext>("The user context is verified", async userContext =>
+            {
+                Assert.IsNotNull(userContext.CurrentUser);
+                await Task.CompletedTask;
+            })
+            .ThenAsync("Done", async ts =>
+            {
+                await Task.CompletedTask;
+            });
+    }
+
+    // === Async step method references ===
+
+    private static async Task AuthenticateUnderAgeUserAsync(IUserRequestContext requestContext)
+    {
+        await Task.Run(() =>
+            requestContext.AuthenticateUser(UserBuilder.Under18User.Email,
+                UserBuilder.Under18User.Password));
+    }
+
+    private static async Task WhenTheUserAddsItemToCartAsync(TestScaffold testScaffold)
+    {
+        var dbContext = testScaffold.Resolve<TestDbContext>();
+        var item = dbContext.Items.FirstOrDefault(i => i.Title == Defaults.CatalogueItems.DeadPool);
+        var shoppingCartService = testScaffold.Resolve<ShoppingCartService>();
+        await testScaffold.CatchAsync<InvalidOperationException>(async () =>
+            await Task.Run(() => shoppingCartService.AddItemToCart(item!.Id)));
+    }
+
+    private static async Task ThenTheUserCanNotAddAgeRestrictedContentAsync(TestScaffold testScaffold)
+    {
+        await testScaffold.HandleAsync<InvalidOperationException>(async ex =>
+        {
+            Assert.IsNotNull(ex);
+            Assert.AreEqual("You must be over 15 to add this item", ex.Message);
+            await Task.CompletedTask;
+        });
+    }
+}


### PR DESCRIPTION
Adds asynchronous BDD test support via a new `TestScaffoldAsyncBddExtensions` static class in `FluentTestScaffold.Bdd`. This provides `Func<TestScaffold, Task>` and `Func<TService, Task>` overloads for all existing BDD step methods (`Given`, `When`, `Then`, `And`, `Catch`, `Handle`), plus `Task<TestScaffold>` extension methods enabling fluent async chaining.

Three layers of extension methods are provided:
- **Async overloads on `TestScaffold`** — entry points that return `Task<TestScaffold>` (e.g. the first async step in a chain)
- **Async + sync overloads on `Task<TestScaffold>`** — for chaining subsequent steps after an async step (supports mixed sync/async chains)
- **Async `Catch<T>(Func<Task>)` and `Handle<T>(Func<T, Task>)`** — async exception capture and assertion

Additionally:
- Two targeted fixes were applied to the existing sync `TestScaffoldBddExtensions`: 
  - `Catch<T>` and `Handle<T>` now have a `where T : Exception` generic constraint (also applied to their async counterparts) 
  - Sync `Handle<T>` fixed to use `TryGetValue` instead of `Get<T>` to avoid `KeyNotFoundException` when no exception was caught
- **Extracted shared helpers into `TestScaffoldBddHelpers`**: Per PR feedback, `PerformAction`, `PerformAction<TService>`, `PerformActionAsync`, `PerformActionAsync<TService>`, and `LogStep` are now in a shared `internal static` utility class. Both `TestScaffoldBddExtensions` and `TestScaffoldAsyncBddExtensions` delegate to these helpers instead of maintaining duplicate private implementations.
- **Fixed `AsyncCatchRethrowsUnexpectedExceptionType` test**: Removed invalid `await` on `Assert.ThrowsAsync<T>()` — NUnit's `ThrowsAsync` returns the caught exception (`T`), not a `Task`, so awaiting it produced `CS1061`.

### Notes
- The async `Catch`/`Handle` methods share the same `"CaughtException"` context key as their sync counterparts, enabling interop between sync and async steps.
- `PerformAction`, `PerformActionAsync`, and `LogStep` are now consolidated in the `internal static TestScaffoldBddHelpers` class, shared by both sync and async extension classes.