### PR TITLE
Added support for OneTimeSetup fixtures (shared TestScaffold), so eac…

### DIFF
--- a/FluentTestScaffold.Core/Builder.cs
+++ b/FluentTestScaffold.Core/Builder.cs
@@ -12,7 +12,7 @@ public class Builder<TBuilder> : IBuilder where TBuilder : Builder<TBuilder>
     private readonly Queue<Action<IServiceProvider>> _buildActions = new();
 
     protected IServiceProvider ServiceProvider => _serviceProvider;
-    protected TestScaffoldContext TestScaffoldContext => _serviceProvider.GetRequiredService<TestScaffoldContext>();
+    protected ITestScaffoldContext TestScaffoldContext => _serviceProvider.GetRequiredService<ITestScaffoldContext>();
 
     /// <summary>
     /// Builder Constructor
@@ -58,8 +58,8 @@ public class Builder<TBuilder> : IBuilder where TBuilder : Builder<TBuilder>
     /// <returns></returns>
     public TBuilder SetTestContext(string key, object value)
     {
-        var testContext = _serviceProvider.GetRequiredService<TestScaffoldContext>();
-        testContext[key] = value;
+        var testContext = _serviceProvider.GetRequiredService<ITestScaffoldContext>();
+        testContext.Set(value, key);
 
         return (TBuilder)this;
     }

--- a/FluentTestScaffold.Core/TestScaffold.cs
+++ b/FluentTestScaffold.Core/TestScaffold.cs
@@ -19,22 +19,42 @@ public class TestScaffold : IDisposable
     /// <summary>
     /// Provides a places to store data during setup that can be accesses later.
     /// </summary>
-    public TestScaffoldContext TestScaffoldContext { get; private set; } = new();
+    public ITestScaffoldContext TestScaffoldContext { get; private set; }
 
     /// <summary>
-    /// Creates an instance of TestScaffold
+    /// Creates an instance of TestScaffold with default context
     /// </summary>
     public TestScaffold()
     {
         Options = ConfigOptions.Default;
+        TestScaffoldContext = new TestScaffoldContext();
     }
 
     /// <summary>
-    /// Creates an instance of TestScaffold with config
+    /// Creates an instance of TestScaffold with a custom context implementation
+    /// </summary>
+    public TestScaffold(ITestScaffoldContext testScaffoldContext)
+    {
+        Options = ConfigOptions.Default;
+        TestScaffoldContext = testScaffoldContext ?? throw new ArgumentNullException(nameof(testScaffoldContext));
+    }
+
+    /// <summary>
+    /// Creates an instance of TestScaffold with config and default context
     /// </summary>
     public TestScaffold(ConfigOptions options)
     {
         Options = options;
+        TestScaffoldContext = new TestScaffoldContext();
+    }
+
+    /// <summary>
+    /// Creates an instance of TestScaffold with config and custom context implementation
+    /// </summary>
+    public TestScaffold(ConfigOptions options, ITestScaffoldContext? testScaffoldContext)
+    {
+        Options = options;
+        TestScaffoldContext = testScaffoldContext ?? new TestScaffoldContext();
     }
 
     /// <summary>
@@ -154,7 +174,7 @@ public class TestScaffold : IDisposable
             configureServices((TServiceBuilder)serviceBuilder);
 
         serviceBuilder.RegisterSingleton(this);
-        serviceBuilder.RegisterSingleton(TestScaffoldContext);
+        serviceBuilder.RegisterSingleton<ITestScaffoldContext>(TestScaffoldContext);
         serviceBuilder.RegisterSingleton(DefaultLogger.Logger);
         serviceBuilder.RegisterBuildersWithAutoDiscovery();
         serviceBuilder.RegisterDataTemplatesWithAutoDiscovery();

--- a/FluentTestScaffold.Core/TestScaffoldContext.cs
+++ b/FluentTestScaffold.Core/TestScaffoldContext.cs
@@ -1,7 +1,26 @@
 namespace FluentTestScaffold.Core;
 
-public class TestScaffoldContext : Dictionary<string, object>
+public interface ITestScaffoldContext
 {
+    bool TryGetValue<TValue>(out TValue? value);
+    bool TryGetValue<TValue>(string? key, out TValue? value);
+    void Set<T>(T? data);
+    void Set<T>(T? data, string? key);
+    void Set<T>(Func<T> func);
+    T Get<T>();
+    T Get<T>(string? key);
+    bool ContainsKey(string key);
+    object? this[string? key] { get; set; }
+}
+
+public class TestScaffoldContext : Dictionary<string, object?>, ITestScaffoldContext
+{
+    object? ITestScaffoldContext.this[string? key]
+    {
+        get => this.GetValueOrDefault(key ?? throw new InvalidOperationException("Key can not be null"));
+        set => base[key ?? throw new InvalidOperationException("Key can not be null")] = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
     public bool TryGetValue<TValue>(out TValue? value)
     {
         return TryGetValue(GetDefaultKey<TValue>(), out value);
@@ -11,7 +30,7 @@ public class TestScaffoldContext : Dictionary<string, object>
     {
         if (key != null && base.TryGetValue(key, out var result))
         {
-            value = TheValueIsAFactoryMethod<TValue>(result) ? CallTheFactoryMethodToGetTheValue<TValue>(result) : (TValue)result;
+            value = TheValueIsAFactoryMethod<TValue>(result) ? CallTheFactoryMethodToGetTheValue<TValue>(result!) : (TValue?)result;
             return true;
         }
 
@@ -24,17 +43,17 @@ public class TestScaffoldContext : Dictionary<string, object>
         return typeof(T).FullName;
     }
 
-    public void Set<T>(T data)
+    public void Set<T>(T? data)
     {
         Set(data, GetDefaultKey<T>());
     }
 
-    public void Set<T>(T data, string? key)
+    public void Set<T>(T? data, string? key)
     {
         if (key == null)
             throw new ArgumentNullException(nameof(key));
-        if (data != null)
-            this[key] = data;
+
+        this[key] = data;
     }
 
     public void Set<T>(Func<T> func)
@@ -51,7 +70,7 @@ public class TestScaffoldContext : Dictionary<string, object>
     {
         var value = this[key ?? throw new ArgumentNullException(nameof(key))];
         if (TheValueIsAFactoryMethod<T>(value))
-            value = CallTheFactoryMethodToGetTheValue<T>(value);
+            value = CallTheFactoryMethodToGetTheValue<T>(value!);
         return (T)value!;
     }
 

--- a/FluentTestScaffold.Nunit/PerTestScaffoldContext.cs
+++ b/FluentTestScaffold.Nunit/PerTestScaffoldContext.cs
@@ -1,0 +1,116 @@
+﻿using System.Collections.Concurrent;
+using FluentTestScaffold.Core;
+using NUnit.Framework;
+
+namespace FluentTestScaffold.Nunit;
+
+/// <summary>
+/// An alternative implementation of ITestScaffoldContext that uses a Dictionary for storage.
+/// This can be used for scenarios requiring different state management strategies.
+/// </summary>
+public class PerTestScaffoldContext : ITestScaffoldContext
+{
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, object?>> _storage = new();
+
+    public bool TryGetValue<TValue>(out TValue? value)
+    {
+        return TryGetValue(GetDefaultKey<TValue>(), out value);
+    }
+
+    public bool TryGetValue<TValue>(string? key, out TValue? value)
+    {
+        var storage = GetCurrentTestContextStorage();
+
+        if (key != null && storage.TryGetValue(key, out var result))
+        {
+            value = TheValueIsAFactoryMethod<TValue>(result)
+                ? CallTheFactoryMethodToGetTheValue<TValue>(result!)
+                : (TValue?)result;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    private string? GetDefaultKey<T>()
+    {
+        return typeof(T).FullName;
+    }
+
+    public void Set<T>(T? data)
+    {
+        Set(data, GetDefaultKey<T>());
+    }
+
+    public void Set<T>(T? data, string? key)
+    {
+        if (key == null)
+            throw new ArgumentNullException(nameof(key));
+
+        var storage = GetCurrentTestContextStorage();
+
+        storage[key] = data;
+    }
+
+    public void Set<T>(Func<T> func)
+    {
+        var storage = GetCurrentTestContextStorage();
+
+        storage[GetDefaultKey<T>() ?? throw new InvalidOperationException("Key can not be null")] = func;
+    }
+
+    public T Get<T>()
+    {
+        return Get<T>(GetDefaultKey<T>());
+    }
+
+    public T Get<T>(string? key)
+    {
+        var storage = GetCurrentTestContextStorage();
+
+        var value = storage[key ?? throw new ArgumentNullException(nameof(key))];
+        if (TheValueIsAFactoryMethod<T>(value))
+            value = CallTheFactoryMethodToGetTheValue<T>(value!);
+        return (T)value!;
+    }
+
+    public bool ContainsKey(string key)
+    {
+        var storage = GetCurrentTestContextStorage();
+        return storage.ContainsKey(key);
+    }
+
+    public object? this[string? key]
+    {
+        get
+        {
+            return Get<object?>(key);
+        }
+
+        set
+        {
+            Set(value, key);
+        }
+    }
+
+    private static T CallTheFactoryMethodToGetTheValue<T>(object value)
+    {
+        return ((Func<T>)value)();
+    }
+
+    private static bool TheValueIsAFactoryMethod<T>(object? value)
+    {
+        if (value == null) return false;
+        return value is Func<T>;
+    }
+
+    private ConcurrentDictionary<string, object?> GetCurrentTestContextStorage()
+    {
+        var testId = TestContext.CurrentContext.Test.ID;
+
+        var storage = _storage.GetOrAdd(testId, _ => new ConcurrentDictionary<string, object?>());
+
+        return storage;
+    }
+}

--- a/Tests/FluentTestScaffold.Tests/Core/BuilderTests.cs
+++ b/Tests/FluentTestScaffold.Tests/Core/BuilderTests.cs
@@ -66,8 +66,8 @@ public class BuilderTests
         var context = testScaffold.TestScaffoldContext;
 
 
-        context.TryGetValue("FirstAdded", out var firstAdded);
-        context.TryGetValue("LastAdded", out var lastAdded);
+        context.TryGetValue<string>("FirstAdded", out var firstAdded);
+        context.TryGetValue<string>("LastAdded", out var lastAdded);
 
 
         Assert.IsNotNull(firstAdded);

--- a/Tests/FluentTestScaffold.Tests/Core/TestContextPerTestScaffoldContextTests.cs
+++ b/Tests/FluentTestScaffold.Tests/Core/TestContextPerTestScaffoldContextTests.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using FluentAssertions;
+using FluentTestScaffold.Core;
+using FluentTestScaffold.Nunit;
+using NUnit.Framework;
+
+namespace FluentTestScaffold.Tests.Core;
+
+[Parallelizable(ParallelScope.Children)]
+public class TestContextPerTestScaffoldContextTests
+{
+    private readonly TestScaffold _testScaffold = new TestScaffold(new PerTestScaffoldContext());
+
+    [Test]
+    public void CanSetContextPerTest()
+    {
+        _testScaffold.TestScaffoldContext.Set<string>("Test");
+
+        _testScaffold.TestScaffoldContext.Get<string>()
+            .Should()
+            .Be("Test");
+    }
+
+    [TestCase("Apple")]
+    [TestCase("Banana")]
+    [TestCase("Pear")]
+    public void CanSetContextPerTestWhenRunInParallel(string testData)
+    {
+        _testScaffold.TestScaffoldContext.Set<string>(testData);
+
+        _testScaffold.TestScaffoldContext.ContainsKey(typeof(string).FullName!).Should().BeTrue();
+
+        _testScaffold.TestScaffoldContext.Get<string>()
+            .Should()
+            .Be(testData);
+
+        _testScaffold.TestScaffoldContext[typeof(string).FullName!]
+            .Should()
+            .Be(testData);
+    }
+
+    [Test]
+    public void TryGetResolvesExistingValueByType()
+    {
+        _testScaffold.TestScaffoldContext.Set("Test Value");
+
+        _testScaffold.TestScaffoldContext.TryGetValue<string>(out var value)
+            .Should()
+            .BeTrue();
+
+        value.Should().Be("Test Value");
+
+    }
+
+    [Test]
+    public void TryGetResolvesExistingValueByKey()
+    {
+        _testScaffold.TestScaffoldContext.Set("Test Value", "Key 1");
+
+        _testScaffold.TestScaffoldContext.TryGetValue<string>("Key 1", out var value)
+            .Should()
+            .BeTrue();
+
+        value.Should().Be("Test Value");
+    }
+
+    [Test]
+    public void TryGetOnUnknownKey()
+    {
+        _testScaffold.TestScaffoldContext.Set("Test Value", "Key 1");
+
+        _testScaffold.TestScaffoldContext.TryGetValue<string>("Key XXX", out var value)
+            .Should()
+            .BeFalse();
+
+        value.Should().Be(null);
+    }
+
+    [Test]
+    public void ThrowsExceptionWhenKeyIsNull()
+    {
+        Action act = () => _testScaffold.TestScaffoldContext.Set("Test Value", null);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void CanSetValueFromFunction()
+    {
+        _testScaffold.TestScaffoldContext.Set(() => "Test Value");
+
+        _testScaffold.TestScaffoldContext.TryGetValue<string>(out var value)
+            .Should()
+            .BeTrue();
+
+        value.Should().Be("Test Value");
+
+        _testScaffold.TestScaffoldContext.Get<string>()
+            .Should()
+            .Be("Test Value");
+    }
+
+    [Test]
+    public void CanDirectlySetKeyValue()
+    {
+        _testScaffold.TestScaffoldContext["Key 1"] = "Test Value";
+
+        var value = _testScaffold.TestScaffoldContext["Key 1"];
+
+        value.Should().Be("Test Value");
+    }
+
+    [Test]
+    public void ThrowsExceptionWhenSettingWithNullKey()
+    {
+        Action act = () => _testScaffold.TestScaffoldContext[null] = "Test Value";
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void CanStoreNullValue()
+    {
+        _testScaffold.TestScaffoldContext["Key 1"] = null;
+
+        var value = _testScaffold.TestScaffoldContext["Key 1"];
+        value.Should().BeNull();
+    }
+}

--- a/Tests/FluentTestScaffold.Tests/Core/TestContextTests.cs
+++ b/Tests/FluentTestScaffold.Tests/Core/TestContextTests.cs
@@ -1,4 +1,5 @@
 using System;
+using FluentAssertions;
 using FluentTestScaffold.Core;
 using NUnit.Framework;
 
@@ -95,6 +96,16 @@ namespace FluentTestScaffold.Tests.Core
         }
 
         [Test]
+        public void TryGetValueWithFactoryMethodWithNull()
+        {
+            var context = new TestScaffoldContext();
+            context.Set<string>((string?)null);
+            bool success = context.TryGetValue<string>(out var retrievedValue);
+            Assert.IsTrue(success);
+            Assert.IsNull(retrievedValue);
+        }
+
+        [Test]
         public void TryGetValueWithNonExistentKey()
         {
             var context = new TestScaffoldContext();
@@ -131,6 +142,25 @@ namespace FluentTestScaffold.Tests.Core
         {
             var context = new TestScaffoldContext();
             Assert.Throws<ArgumentNullException>(() => context.Get<int>(null));
+        }
+
+        [Test]
+        public void SetNullValue()
+        {
+            var context = new TestScaffoldContext();
+
+            context.Set("Test value", "Key");
+
+            context.Get<string>("Key")
+                .Should()
+                .Be("Test value");
+
+
+            context.Set<string>(null, "Key");
+
+            context.Get<string>("Key")
+                .Should()
+                .BeNull();
         }
     }
 }

--- a/Tests/FluentTestScaffold.Tests/Core/TestScaffoldTests.cs
+++ b/Tests/FluentTestScaffold.Tests/Core/TestScaffoldTests.cs
@@ -185,7 +185,7 @@ public class TestScaffoldTests
         });
 
         // Verify the exception message indicates the issue
-        Assert.IsTrue(exception.Message.Contains("MockService") ||
+        Assert.IsTrue(exception!.Message.Contains("MockService") ||
                      exception.Message.Contains("object") ||
                      exception.Message.Contains("Unable to resolve") ||
                      exception.Message.Contains("No service for type"),


### PR DESCRIPTION
…h test can maintain their own TestScaffoldContext without clobbering each other's data.